### PR TITLE
normalize test output

### DIFF
--- a/core_test/example.t
+++ b/core_test/example.t
@@ -1,3 +1,5 @@
+  $ export MOON_HOME="${MOON_HOME:-$HOME/.moon}"
+  $ export BUILD_PATH_PREFIX_MAP="\$MOON_HOME=$MOON_HOME:$BUILD_PATH_PREFIX_MAP"
 Test moon ide doc for core library functions (checking header only for stability):
   $ moon ide doc 'String::length' | head -5
   package "moonbitlang/core/string"
@@ -21,10 +23,6 @@ Test moon ide doc for Option type (header only):
   
     pub fn[T, U] Option::bind(T?, (T) -> U? raise?) -> U? raise?
     pub fn[X : Compare] Option::compare(X?, X?) -> Int
-
-TODO(doc-unqualified): moon ide doc 'HashMap' doesn't work without package prefix:
-  $ moon ide doc 'HashMap'
-  No results found for query: 'HashMap'
 
 Test moon ide doc for @hashmap.HashMap (with package prefix, header only):
   $ moon ide doc '@hashmap.HashMap' | head -5

--- a/core_test/test_project/test.t
+++ b/core_test/test_project/test.t
@@ -1,3 +1,5 @@
+  $ export MOON_HOME="${MOON_HOME:-$HOME/.moon}"
+  $ export BUILD_PATH_PREFIX_MAP="\$MOON_HOME=$MOON_HOME:$BUILD_PATH_PREFIX_MAP"
 Test peek-def for String::length:
   $ moon ide peek-def 'String::length' 2>&1 | grep -E "^Found"
   Found 1 symbols matching 'String::length':
@@ -36,15 +38,15 @@ TODO(peek-def-tuple-alias): peek-def for Hello matches a spurious symbol from co
   $ moon ide peek-def Hello 2>&1 | head -4
   Found 2 symbols matching 'Hello':
   
-  `struct Hello` in package moonbitlang/core/json_blackbox_test at /Users/hongbozhang/.moon/lib/core/json/derive_json_test.mbt:15-20
+  `struct Hello` in package moonbitlang/core/json_blackbox_test at $MOON_HOME/lib/core/json/derive_json_test.mbt:15-20
   15 | ///|
 
 
 Test find-references for String::length:
 FIXME it is unclear this semantics is what we want
   $ moon ide find-references 'String::length' 2>&1 | head -6
-  `pub fn String::length` in package moonbitlang/core/builtin at /Users/hongbozhang/.moon/lib/core/builtin/intrinsics.mbt:1729-1750
-  1729 | ///|
+  `pub fn String::length` in package moonbitlang/core/builtin at $MOON_HOME/lib/core/builtin/intrinsics.mbt:1708-1729
+  1708 | ///|
        | /// Returns the number of UTF-16 code units in the string. Note that this is not
        | /// necessarily equal to the number of Unicode characters (code points) in the
        | /// string, as some characters may be represented by multiple UTF-16 code units.

--- a/core_test/test_project/test.t
+++ b/core_test/test_project/test.t
@@ -23,11 +23,17 @@ Test peek-def for Heyx (type alias to named type):
   3 | type Heyx = @list.List[Int]
 
 
-TODO wrong output
-Test peek-def --loc for Heyx at usage site (line 5):
-  $ moon ide peek-def Heyx --loc tuple_type_bug.mbt:5 2>&1 | head -2
+  $ moon ide peek-def Heyx --loc tuple_type_bug.mbt:5 2>&1 | head -10
   Definition found at file $TESTCASE_ROOT/tuple_type_bug.mbt
     | type Hello = (Int, String)
+    | 
+  3 | type Heyx = @list.List[Int]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    | 
+    | fn hello(x : Hello, y : Heyx ) -> Int {
+    |   0
+    | }
+  Definition found at file $MOON_HOME/lib/core/list/types.mbt
 
 TODO(peek-def-tuple-alias): peek-def --loc for Hello at usage site fails for tuple type alias
   $ moon ide peek-def Hello --loc tuple_type_bug.mbt:5 2>&1


### PR DESCRIPTION
1. normalize dune test output using BUILD_PREFIX_MAP (https://dune.readthedocs.io/en/stable/tests.html#test-output-sanitation)
2. Fix/Remove wrong tests:
   1. `moon ide doc HashMap` returns no result is intended, since `@hashmap.HashMap` is not reexported by prelude, so users must use qualified type
   2. `moon ide peek-def Heyx --loc tuple_type_bug.mbt:5`. Output is correct, but head -2 truncates the output, causing a wrong look output.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/moon-ide-tests/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
