### PR TITLE
ci: fix Windows daily cram log capture

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -105,6 +105,7 @@ jobs:
           name: daily-unix-review-inputs
           path: .daily-test
           if-no-files-found: ignore
+          include-hidden-files: true
 
   windows-baseline:
     name: Windows Baselines
@@ -156,7 +157,7 @@ jobs:
         shell: powershell
         run: |
           New-Item -ItemType Directory -Force -Path .daily-test | Out-Null
-          & moon cram test --cram-compat --no-keep-output-crlf --shell scripts\moon-cram-powershell.cmd tests\windows *> .daily-test\windows-cram-test.log
+          cmd.exe /D /C "moon cram test --cram-compat --no-keep-output-crlf --shell scripts\moon-cram-powershell.cmd tests\windows > .daily-test\windows-cram-test.log 2>&1"
           $status = $LASTEXITCODE
           Set-Content -Path .daily-test\windows-cram-test-status.txt -Value $status -Encoding utf8
           "status=$status" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
@@ -189,6 +190,7 @@ jobs:
           name: daily-windows-review-inputs
           path: .daily-test
           if-no-files-found: ignore
+          include-hidden-files: true
 
   daily-review:
     name: Daily Review

--- a/tests/unix/core-project/find-references.mooncram.md
+++ b/tests/unix/core-project/find-references.mooncram.md
@@ -324,11 +324,11 @@ Found 2 references for symbol 'map':
 ```mooncram
 $ run_moon_ide moon ide find-references 'map' --loc 'core_ide_cases.mbt:43:15'
 Found 3 references for symbol 'map':
-<MOON_HOME>/lib/core/builtin/iterator.mbt:357:20-357:23:
+<MOON_HOME>/lib/core/builtin/iterator.mbt:358:20-358:23:
     | /// (escaped)
     | /// # Note (escaped)
     | /// The old iterator `self` must not be used again after calling `map`. (escaped)
-357 | pub fn[X, Y] Iter::map(self : Iter[X], f : (X) -> Y) -> Iter[Y] {
+358 | pub fn[X, Y] Iter::map(self : Iter[X], f : (X) -> Y) -> Iter[Y] {
     |                    ^^^ (escaped)
     |   { (escaped)
     |     f: fn() { (escaped)
@@ -356,11 +356,11 @@ Found 3 references for symbol 'map':
 ```mooncram
 $ run_moon_ide moon ide find-references 'map' --loc 'core_ide_cases.mbt:48:6'
 Found 2 references for symbol 'map':
-<MOON_HOME>/lib/core/list/list.mbt:254:20-254:23:
+<MOON_HOME>/lib/core/list/list.mbt:255:20-255:23:
     | /// } (escaped)
     | /// ``` (escaped)
     | #locals(f) (escaped)
-254 | pub fn[A, B] List::map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
+255 | pub fn[A, B] List::map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
     |                    ^^^ (escaped)
     |   match self { (escaped)
     |     Empty => Empty (escaped)
@@ -402,11 +402,11 @@ Found 2 references for symbol 'get':
 ```mooncram
 $ run_moon_ide moon ide find-references 'map' --loc 'core_ide_cases.mbt:60:10'
 Found 2 references for symbol 'map':
-<MOON_HOME>/lib/core/hashmap/hashmap.mbt:798:27-798:30:
+<MOON_HOME>/lib/core/hashmap/hashmap.mbt:823:27-823:30:
     | ///| (escaped)
     | /// Applies a function to each key-value pair in the map and  (escaped)
     | /// returns a new map with the results, using the original keys. (escaped)
-798 | pub fn[K, V, V2] HashMap::map(
+823 | pub fn[K, V, V2] HashMap::map(
     |                           ^^^ (escaped)
     |   self : HashMap[K, V], (escaped)
     |   f : (K, V) -> V2, (escaped)
@@ -525,11 +525,11 @@ Found 2 references for symbol 'from_array':
 ```mooncram
 $ run_moon_ide moon ide find-references 'from_array' --loc 'core_ide_cases.mbt:84:9'
 Found 2 references for symbol 'from_array':
-<MOON_HOME>/lib/core/list/list.mbt:168:17-168:27:
+<MOON_HOME>/lib/core/list/list.mbt:169:17-169:27:
     | #as_free_fn (escaped)
     | #alias(of, deprecated="Use from_array instead") (escaped)
     | #as_free_fn(of, deprecated="Use from_array instead") (escaped)
-168 | pub fn[A] List::from_array(arr : ArrayView[A]) -> List[A] {
+169 | pub fn[A] List::from_array(arr : ArrayView[A]) -> List[A] {
     |                 ^^^^^^^^^^ (escaped)
     |   for i = arr.length() - 1, list = Empty; i >= 0; { (escaped)
     |     continue i - 1, More(arr[i], tail=list) (escaped)

--- a/tests/unix/core-project/peek-def.mooncram.md
+++ b/tests/unix/core-project/peek-def.mooncram.md
@@ -269,7 +269,7 @@ Definition found at file <MOON_HOME>/lib/core/builtin/iterator.mbt
     | /// Collects the elements of the iterator into an array. (escaped)
     | /// The old iterator `self` must not be used again. (escaped)
     | #alias(collect) (escaped)
-810 | pub fn[X] Iter::to_array(self : Iter[X]) -> Array[X] {
+811 | pub fn[X] Iter::to_array(self : Iter[X]) -> Array[X] {
     |                 ^^^^^^^^ (escaped)
     |   let result = match self.size_hint { (escaped)
     |     Some(n) => Array::new(capacity=n) (escaped)
@@ -391,7 +391,7 @@ Definition found at file <MOON_HOME>/lib/core/builtin/iterator.mbt
     | /// (escaped)
     | /// # Note (escaped)
     | /// The old iterator `self` must not be used again after calling `map`. (escaped)
-357 | pub fn[X, Y] Iter::map(self : Iter[X], f : (X) -> Y) -> Iter[Y] {
+358 | pub fn[X, Y] Iter::map(self : Iter[X], f : (X) -> Y) -> Iter[Y] {
     |                    ^^^ (escaped)
     |   { (escaped)
     |     f: fn() { (escaped)
@@ -417,7 +417,7 @@ Definition found at file <MOON_HOME>/lib/core/builtin/iterator.mbt
     | /// Collects the elements of the iterator into an array. (escaped)
     | /// The old iterator `self` must not be used again. (escaped)
     | #alias(collect) (escaped)
-810 | pub fn[X] Iter::to_array(self : Iter[X]) -> Array[X] {
+811 | pub fn[X] Iter::to_array(self : Iter[X]) -> Array[X] {
     |                 ^^^^^^^^ (escaped)
     |   let result = match self.size_hint { (escaped)
     |     Some(n) => Array::new(capacity=n) (escaped)
@@ -443,7 +443,7 @@ Definition found at file <MOON_HOME>/lib/core/list/list.mbt
     | /// } (escaped)
     | /// ``` (escaped)
     | #locals(f) (escaped)
-254 | pub fn[A, B] List::map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
+255 | pub fn[A, B] List::map(self : List[A], f : (A) -> B raise?) -> List[B] raise? {
     |                    ^^^ (escaped)
     |   match self { (escaped)
     |     Empty => Empty (escaped)
@@ -521,7 +521,7 @@ Definition found at file <MOON_HOME>/lib/core/hashmap/hashmap.mbt
     | ///| (escaped)
     | /// Applies a function to each key-value pair in the map and  (escaped)
     | /// returns a new map with the results, using the original keys. (escaped)
-798 | pub fn[K, V, V2] HashMap::map(
+823 | pub fn[K, V, V2] HashMap::map(
     |                           ^^^ (escaped)
     |   self : HashMap[K, V], (escaped)
     |   f : (K, V) -> V2, (escaped)
@@ -599,7 +599,7 @@ Definition found at file <MOON_HOME>/lib/core/builtin/iterator.mbt
     | /// (escaped)
     | /// # Note (escaped)
     | /// The old iterator `self` must not be used again after calling `filter`. (escaped)
-326 | pub fn[X] Iter::filter(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
+327 | pub fn[X] Iter::filter(self : Iter[X], f : (X) -> Bool) -> Iter[X] {
     |                 ^^^^^^ (escaped)
     |   Iter::new(fn() { (escaped)
     |     while self.next() is Some(x) { (escaped)
@@ -625,7 +625,7 @@ Definition found at file <MOON_HOME>/lib/core/list/list.mbt
     | #as_free_fn (escaped)
     | #alias(of, deprecated="Use from_array instead") (escaped)
     | #as_free_fn(of, deprecated="Use from_array instead") (escaped)
-168 | pub fn[A] List::from_array(arr : ArrayView[A]) -> List[A] {
+169 | pub fn[A] List::from_array(arr : ArrayView[A]) -> List[A] {
     |                 ^^^^^^^^^^ (escaped)
     |   for i = arr.length() - 1, list = Empty; i >= 0; { (escaped)
     |     continue i - 1, More(arr[i], tail=list) (escaped)
@@ -647,7 +647,7 @@ Definition found at file <MOON_HOME>/lib/core/list/list.mbt
     | #as_free_fn (escaped)
     | #alias(of, deprecated="Use from_array instead") (escaped)
     | #as_free_fn(of, deprecated="Use from_array instead") (escaped)
-168 | pub fn[A] List::from_array(arr : ArrayView[A]) -> List[A] {
+169 | pub fn[A] List::from_array(arr : ArrayView[A]) -> List[A] {
     |                 ^^^^^^^^^^ (escaped)
     |   for i = arr.length() - 1, list = Empty; i >= 0; { (escaped)
     |     continue i - 1, More(arr[i], tail=list) (escaped)

--- a/tests/unix/core-standalone/peek-def.mooncram.md
+++ b/tests/unix/core-standalone/peek-def.mooncram.md
@@ -363,8 +363,8 @@ Found 1 symbols matching 'Result::map':
 $ run_moon_ide moon ide peek-def 'Iter::map'
 Found 1 symbols matching 'Iter::map':
 
-`pub fn Iter::map` in package moonbitlang/core/builtin at <MOON_HOME>/lib/core/builtin/iterator.mbt:338-367
-338 | ///|
+`pub fn Iter::map` in package moonbitlang/core/builtin at <MOON_HOME>/lib/core/builtin/iterator.mbt:339-368
+339 | ///|
     | /// Transforms the elements of the iterator using a mapping function. (escaped)
     | /// (escaped)
     | /// # Type Parameters (escaped)
@@ -400,8 +400,8 @@ Found 1 symbols matching 'Iter::map':
 $ run_moon_ide moon ide peek-def 'Iter::filter'
 Found 1 symbols matching 'Iter::filter':
 
-`pub fn Iter::filter` in package moonbitlang/core/builtin at <MOON_HOME>/lib/core/builtin/iterator.mbt:308-336
-308 | ///|
+`pub fn Iter::filter` in package moonbitlang/core/builtin at <MOON_HOME>/lib/core/builtin/iterator.mbt:309-337
+309 | ///|
     | /// Filters the elements of the iterator based on a predicate function. (escaped)
     | /// (escaped)
     | /// # Type Parameters (escaped)
@@ -436,8 +436,8 @@ Found 1 symbols matching 'Iter::filter':
 $ run_moon_ide moon ide peek-def 'Iter::to_array'
 Found 1 symbols matching 'Iter::to_array':
 
-`pub fn Iter::to_array` in package moonbitlang/core/builtin at <MOON_HOME>/lib/core/builtin/iterator.mbt:806-819
-806 | ///|
+`pub fn Iter::to_array` in package moonbitlang/core/builtin at <MOON_HOME>/lib/core/builtin/iterator.mbt:807-820
+807 | ///|
     | /// Collects the elements of the iterator into an array. (escaped)
     | /// The old iterator `self` must not be used again. (escaped)
     | #alias(collect) (escaped)
@@ -471,8 +471,8 @@ Found 1 symbols matching '@moonbitlang/core/list.List':
 $ run_moon_ide moon ide peek-def '@moonbitlang/core/list.List::map'
 Found 1 symbols matching '@moonbitlang/core/list.List::map':
 
-`pub fn List::map` in package moonbitlang/core/list at <MOON_HOME>/lib/core/list/list.mbt:240-273
-240 | ///|
+`pub fn List::map` in package moonbitlang/core/list at <MOON_HOME>/lib/core/list/list.mbt:241-274
+241 | ///|
     | /// Maps the list. (escaped)
     | /// (escaped)
     | /// # Example (escaped)
@@ -563,8 +563,8 @@ Found 2 symbols matching '@moonbitlang/core/hashmap.HashMap::get':
 $ run_moon_ide moon ide peek-def '@moonbitlang/core/hashmap.HashMap::map'
 Found 2 symbols matching '@moonbitlang/core/hashmap.HashMap::map':
 
-`pub fn HashMap::map` in package moonbitlang/core/hashmap at <MOON_HOME>/lib/core/hashmap/hashmap.mbt:795-817
-795 | ///|
+`pub fn HashMap::map` in package moonbitlang/core/hashmap at <MOON_HOME>/lib/core/hashmap/hashmap.mbt:820-842
+820 | ///|
     | /// Applies a function to each key-value pair in the map and  (escaped)
     | /// returns a new map with the results, using the original keys. (escaped)
     | pub fn[K, V, V2] HashMap::map( (escaped)


### PR DESCRIPTION
## Summary
- capture Windows daily `moon cram test` output through `cmd.exe` so native stderr does not trip GitHub's PowerShell wrapper before status files are written
- upload `.daily-test` review inputs with `include-hidden-files: true` so failure diagnostics are preserved
- refresh Unix core IDE baselines with the latest CI-installed MoonBit toolchain (`moon 0.1.20260608`), updating core library line-number expectations

## Verification
- `curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash`
- `moon version` -> `moon 0.1.20260608 (60bc8c3 2026-06-08)`
- `scripts/update-submodules.sh`
- `moon update`
- `moon -C testgen test --target wasm`
- `scripts/update-tests.sh`
- `moon cram update --replace --assume-yes --cram-compat tests/unix`
- `moon cram test --cram-compat tests/unix` -> 36 documents, 472 testcases, 472 succeeded
- `git diff --check`
- `./scripts/update-windows-tests.ps1 -RefreshSnapshots`
- `moon cram test --cram-compat --no-keep-output-crlf --shell scripts\\moon-cram-powershell.cmd tests\\windows` locally via the workflow capture path: 28 documents, 187 testcases, 187 succeeded

No generated Windows baseline diffs were produced by the local daily run.