### PR TITLE
[codex] ci: write Windows cram status as ASCII

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -159,7 +159,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path .daily-test | Out-Null
           cmd.exe /D /C "moon cram test --cram-compat --no-keep-output-crlf --shell scripts\moon-cram-powershell.cmd tests\windows > .daily-test\windows-cram-test.log 2>&1"
           $status = $LASTEXITCODE
-          Set-Content -Path .daily-test\windows-cram-test-status.txt -Value $status -Encoding utf8
+          [System.IO.File]::WriteAllText(".daily-test\windows-cram-test-status.txt", [string]$status, [System.Text.Encoding]::ASCII)
           "status=$status" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           exit 0
 


### PR DESCRIPTION
## Summary

- Write the Windows cram test status artifact with ASCII encoding instead of Windows PowerShell UTF-8.
- Avoid a UTF-8 BOM in `.daily-test/windows-cram-test-status.txt`, so the Ubuntu daily-review Bash guard can compare the status value exactly against `0`.

## Root Cause

The Windows daily workflow wrote `windows-cram-test-status.txt` with `Set-Content -Encoding utf8` under Windows PowerShell. That produced a BOM before the numeric status, so the later Ubuntu Bash step read the value as not exactly `0` and failed the no-diff guard even though the Windows cram tests passed.

## Validation

- `git diff --cached --check`
- `git diff --check origin/main...HEAD`

PowerShell is not installed in this local environment, so the Windows-specific write path still needs GitHub Actions validation.