### PR TITLE
[codex] ci: update actions to Node 24 majors

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -23,7 +23,7 @@ jobs:
     name: Unix Baselines
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload Unix review inputs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: daily-unix-review-inputs
           path: .daily-test
@@ -112,7 +112,7 @@ jobs:
     runs-on: windows-latest
     needs: daily-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload Windows review inputs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: daily-windows-review-inputs
           path: .daily-test
@@ -199,7 +199,7 @@ jobs:
       - daily-test
       - windows-baseline
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -212,13 +212,13 @@ jobs:
           git submodule update --init --recursive
 
       - name: Download Unix review inputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: daily-unix-review-inputs
           path: .daily-test
 
       - name: Download Windows review inputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: daily-windows-review-inputs
           path: .daily-test
@@ -331,7 +331,7 @@ jobs:
 
       - name: Comment on pull request
         if: steps.diff.outputs.has_changes == 'true' && steps.codex-result.outputs.has_problem == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           COMMENT_BODY: ${{ steps.codex-result.outputs.comment_body }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
   baseline:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -45,7 +45,7 @@ jobs:
   windows-baseline:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 


### PR DESCRIPTION
## Summary

- update GitHub-owned workflow actions to Node 24 major releases
- cover the Daily Test workflow warnings for checkout, upload-artifact, and download-artifact
- update the PR workflow checkout actions and the conditional github-script step to avoid the same deprecated runtime class

## Why

GitHub Actions runners now warn when Node 20 actions are forced to run on Node 24. The linked Daily Test run reported warnings for `actions/checkout@v4`, `actions/upload-artifact@v4`, and `actions/download-artifact@v4`.

## Validation

- `rg -n "actions/(checkout|upload-artifact|download-artifact)@v4|actions/github-script@v7" .github/workflows || true`
- `rg -n "actions/(checkout@v7|upload-artifact@v7|download-artifact@v8|github-script@v9)" .github/workflows`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "ok #{p}" }' .github/workflows/daily.yml .github/workflows/pr.yml`